### PR TITLE
Handle low limits in sieve_of_eratosthenes

### DIFF
--- a/fizzbuzz.py
+++ b/fizzbuzz.py
@@ -28,6 +28,8 @@ def get_primes(n_max):
 
 def sieve_of_eratosthenes(n_max):
     """Generate primes till n_max using the Sieve of Eratosthenes."""
+    if n_max < 2:
+        return []
     sieve = [True] * (n_max + 1)
     sieve[0] = sieve[1] = False
     for start in range(2, int(n_max**0.5) + 1):

--- a/strings_algorithms.py
+++ b/strings_algorithms.py
@@ -65,6 +65,8 @@ def armstrong_in_range(start, end):
 
 def sieve_of_eratosthenes(limit):
     """Print all prime numbers in a range using Sieve of Eratosthenes."""
+    if limit < 2:
+        return []
     primes = [True] * (limit + 1)
     primes[0] = primes[1] = False
     for i in range(2, int(limit**0.5) + 1):

--- a/test_fizzbuzz.py
+++ b/test_fizzbuzz.py
@@ -31,6 +31,7 @@ class TestFizzBuzz(unittest.TestCase):
             sieve_of_eratosthenes(10), [2, "Fizz", "Buzz", 7]
         )  # Ensure raw primes are returned
         self.assertEqual(sieve_of_eratosthenes(1), [])
+        self.assertEqual(sieve_of_eratosthenes(0), [])
         self.assertEqual(sieve_of_eratosthenes(2), [2])
 
 

--- a/test_strings_algorithms.py
+++ b/test_strings_algorithms.py
@@ -70,6 +70,7 @@ class TestStringsAlgorithms(unittest.TestCase):
         Test the sieve_of_eratosthenes function with a sample limit.
         """
         self.assertEqual(sieve_of_eratosthenes(10), [2, 3, 5, 7])
+        self.assertEqual(sieve_of_eratosthenes(0), [])
 
     def test_word_frequency(self):
         """


### PR DESCRIPTION
## Summary
- Prevent sieve_of_eratosthenes in fizzbuzz and strings_algorithms from crashing when given limits below 2
- Extend unit tests to cover zero-limit cases for sieve_of_eratosthenes

## Testing
- `pip install pandas` *(fails: Could not find a version that satisfies the requirement pandas)*
- `pytest test_fizzbuzz.py test_strings_algorithms.py test_number_algorithms.py test_synthetic_data.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa72b0266c8330b6413cb421b33b64